### PR TITLE
[NOJIRA]: remove doubled CI checks

### DIFF
--- a/.github/workflows/bode_ci.yaml
+++ b/.github/workflows/bode_ci.yaml
@@ -7,6 +7,9 @@ on:
   push:
     paths:
       - "bode/**"
+    branches:
+      - develop
+      - master
 
 jobs:
   ci:

--- a/.github/workflows/cabra_ci.yaml
+++ b/.github/workflows/cabra_ci.yaml
@@ -7,6 +7,9 @@ on:
   push:
     paths:
       - "cabra/**"
+    branches:
+      - develop
+      - master
 
 jobs:
   ci:


### PR DESCRIPTION
<!--
- [ ] Provide a summary of the features and changes
- [ ] Assign one or more reviewers
-->
## Why these changes?
CI checks are run on every push to the branch including merging from `develop`. This creates duplicated CI checks that are a bit unnecessary. In the screenshot below, there are checks for a PR that is touching only `bode` after updating from `develop`.
![image](https://user-images.githubusercontent.com/56299613/163849179-3791422d-322b-4ea9-b5ef-3712cf814426.png)

<!-- Include links to relevant Jira stories or visual resources. -->
