### PR TITLE
[ITG-99, ITG-100] Update directed relations naming and change relations order in task details

### DIFF
--- a/bode/bode/models/task_relation.py
+++ b/bode/bode/models/task_relation.py
@@ -28,7 +28,7 @@ class TaskRelation(db.Model):
     T2 := second_task_id
 
     type = SUBTASKS -> T2 is subtask of T1
-    type = DEPENDET -> T2 is dependent on T1
+    type = DEPENDENT -> T2 is dependent on T1
     type = INTERCHANGABLE -> T1 is interchangable with T2 and (T2, T1, INTERCHANGABLE) record is in the database
     """
 

--- a/bode/bode/resources/task_relations/api.py
+++ b/bode/bode/resources/task_relations/api.py
@@ -46,7 +46,7 @@ class TasksRelationsById(MethodView):
 class TasksInRelationWith(MethodView):
     def lhs_relation_filter(self, relation_type: str):
         match relation_type:
-            case DirectedRelationType.DependsOn.value:
+            case DirectedRelationType.IsBlockedBy.value:
                 return TaskRelation.type == RelationType.Dependent.value
             case DirectedRelationType.Subtask.value:
                 return TaskRelation.type == RelationType.Subtask.value
@@ -57,7 +57,7 @@ class TasksInRelationWith(MethodView):
 
     def rhs_relation_filter(self, relation_type):
         match relation_type:
-            case DirectedRelationType.IsDependentOn.value:
+            case DirectedRelationType.Blocks.value:
                 return TaskRelation.type == RelationType.Dependent.value
             case DirectedRelationType.Supertask.value:
                 return TaskRelation.type == RelationType.Subtask.value
@@ -70,9 +70,9 @@ class TasksInRelationWith(MethodView):
         match relation.type:
             case RelationType.Dependent.value:
                 type = (
-                    DirectedRelationType.IsDependentOn.value
+                    DirectedRelationType.Blocks.value
                     if task.id == relation.first_task_id
-                    else DirectedRelationType.DependsOn.value
+                    else DirectedRelationType.IsBlockedBy.value
                 )
             case RelationType.Subtask.value:
                 type = (

--- a/bode/bode/resources/task_relations/schemas.py
+++ b/bode/bode/resources/task_relations/schemas.py
@@ -26,8 +26,8 @@ class SimpleTaskRelationSchema(BaseSchema):
 
 
 class DirectedRelationType(Enum):
-    IsDependentOn = "is_dependent_on"
-    DependsOn = "depends_on"
+    Blocks = "blocks"
+    IsBlockedBy = "is_blocked_by"
     Subtask = "subtask"
     Supertask = "supertask"
     Interchangable = "interchangable"
@@ -38,8 +38,8 @@ class DirectedRelationType(Enum):
 
 
 SYMMETRIC_RELATION_TYPES = [DirectedRelationType.Interchangable.value]
-LHS_RELATION_TYPES = [DirectedRelationType.DependsOn.value, DirectedRelationType.Subtask.value]
-RHS_RELATION_TYPES = [DirectedRelationType.IsDependentOn.value, DirectedRelationType.Supertask.value]
+LHS_RELATION_TYPES = [DirectedRelationType.IsBlockedBy.value, DirectedRelationType.Subtask.value]
+RHS_RELATION_TYPES = [DirectedRelationType.Blocks.value, DirectedRelationType.Supertask.value]
 
 
 class DirectedRelationSchema(BaseSchema):

--- a/cabra/src/pages/components/RelatedTaskList.tsx
+++ b/cabra/src/pages/components/RelatedTaskList.tsx
@@ -25,18 +25,17 @@ export default function RelatedTasksList({
   const navigate = useNavigate();
 
   if (isLoading) return <div>Loading</div>;
-  if (error) return <div>Oops</div>;
-  if (!data?.data) return <div />;
+  if (error || !data?.data) return <div>Oops</div>;
 
-  const subtasks = data.data.slice().reverse();
+  const relatedTasks = data.data;
 
-  if (subtasks.length === 0) {
+  if (relatedTasks.length === 0) {
     return <div>{"<No tasks>"}</div>;
   }
 
   return (
     <div className={className}>
-      {subtasks.map(({ relationId, task }) => (
+      {relatedTasks.map(({ relationId, task }) => (
         <RelatedTask
           key={relationId}
           task={task}

--- a/cabra/src/pages/components/TaskDetailsCard.tsx
+++ b/cabra/src/pages/components/TaskDetailsCard.tsx
@@ -75,21 +75,21 @@ export default function TaskDetails({ id }: Props) {
             tw="flex"
           />
         </CardField>
-        <CardField title="Is dependent on" span={1}>
+        <CardField title="Is blocked by" span={1}>
           <RelatedTasksList
-            relationType={DirectedRelationType.IsDependentOn}
-            parentTaskId={id}
-          />
-        </CardField>
-        <CardField title="Depends on" span={1}>
-          <RelatedTasksList
-            relationType={DirectedRelationType.DependsOn}
+            relationType={DirectedRelationType.IsBlockedBy}
             parentTaskId={id}
           />
         </CardField>
         <CardField title="Interchangeable tasks" span={1}>
           <RelatedTasksList
             relationType={DirectedRelationType.Interchangable}
+            parentTaskId={id}
+          />
+        </CardField>
+        <CardField title="Blocks" span={1}>
+          <RelatedTasksList
+            relationType={DirectedRelationType.Blocks}
             parentTaskId={id}
           />
         </CardField>

--- a/cabra/src/pages/components/TaskRelationsEdit.tsx
+++ b/cabra/src/pages/components/TaskRelationsEdit.tsx
@@ -10,25 +10,28 @@ import { useQuery } from "react-query";
 import { useState } from "react";
 
 const Container = styled.div(tw`text-gray-50 w-full space-y-4`);
+
 interface Props {
   readonly taskId: string;
 }
+
 interface RelationshipOption {
   readonly value: DirectedRelationType;
   readonly label: string;
 }
+
 interface TaskOption {
   value: ITask;
   label: string;
 }
 
 const relationshipOptions: RelationshipOption[] = [
-  { value: DirectedRelationType.DependsOn, label: "Depends on" },
-  { value: DirectedRelationType.IsDependentOn, label: "Is dependent on" },
+  { value: DirectedRelationType.IsBlockedBy, label: "Is blocked by" },
+  { value: DirectedRelationType.Blocks, label: "Blocks" },
   { value: DirectedRelationType.Interchangable, label: "Interchangeable" },
 ];
 
-const DEFAULT_RELATION_TYPE = DirectedRelationType.DependsOn;
+const DEFAULT_RELATION_TYPE = DirectedRelationType.IsBlockedBy;
 
 export default function TaskRelationsEdit({ taskId }: Props) {
   const [tasksRelation, setTaskRelation] = useState<DirectedRelationType>(

--- a/cabra/src/types/taskRelation.ts
+++ b/cabra/src/types/taskRelation.ts
@@ -14,8 +14,8 @@ export interface IRelatedTask {
 }
 
 export enum DirectedRelationType {
-  IsDependentOn = "is_dependent_on",
-  DependsOn = "depends_on",
+  Blocks = "blocks",
+  IsBlockedBy = "is_blocked_by",
   Subtask = "subtask",
   Supertask = "supertask",
   Interchangable = "interchangable",


### PR DESCRIPTION
Updated directed relations naming to use `blocks` and `is blocked by` and changed the order of columns in task details to be chronological

<!--
- [ ] Provide a summary of the features and changes
- [ ] Assign one or more reviewers
-->

---

#### Resources

[ITG-99](https://kulawska.atlassian.net/browse/ITG-99)
[ITG-100](https://kulawska.atlassian.net/browse/ITG-100)
